### PR TITLE
WRC-17 Add user_show_me action

### DIFF
--- a/ckanext/who_romania/actions.py
+++ b/ckanext/who_romania/actions.py
@@ -1,14 +1,47 @@
 import logging
 import random
 import re
-import secrets
 
 import ckan.plugins.toolkit as toolkit
 from ckan.plugins.toolkit import ValidationError, _
-from ckan.logic import NotFound
 
 
 log = logging.getLogger(__name__)
+
+
+@toolkit.side_effect_free
+def user_show_me(context, resource_dict):
+    """
+    Returns the current user object.  Raises NotAuthorized error if no user
+    object found.
+
+    No input params.
+
+    :rtype dictionary
+    :returns The user object as a dictionary, which takes the following structure:
+        ```
+            {
+                "id": "7f88caf3-e68b-4c96-883e-b49f3d547d84",
+                "name": "fjelltopp_editor",
+                "fullname": "Fjelltopp Editor",
+                "email": "fjelltopp_editor@fjelltopp.org",
+                "created": "2021-10-29 12:51:56.277305",
+                "reset_key": null,
+                "about": null,
+                "activity_streams_email_notifications": false,
+                "sysadmin": false,
+                "state": "active",
+                "image_url": null,
+                "plugin_extras": null
+            }
+        ```
+
+    """
+    auth_user_obj = context.get('auth_user_obj')
+    if auth_user_obj:
+        return auth_user_obj.as_dict()
+    else:
+        raise toolkit.NotAuthorized
 
 
 def dataset_duplicate(context, data_dict):

--- a/ckanext/who_romania/plugin.py
+++ b/ckanext/who_romania/plugin.py
@@ -84,7 +84,8 @@ class WHORomaniaPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
             'user_list': who_romania_actions.user_list,
             'dataset_duplicate': who_romania_actions.dataset_duplicate,
             'package_create': who_romania_actions.package_create,
-            'dataset_tag_replace': who_romania_actions.dataset_tag_replace
+            'dataset_tag_replace': who_romania_actions.dataset_tag_replace,
+            'user_show_me': who_romania_actions.user_show_me
         }
 
     # IValidators

--- a/ckanext/who_romania/tests/test_actions.py
+++ b/ckanext/who_romania/tests/test_actions.py
@@ -1,6 +1,8 @@
 import pytest
 import ckan.tests.factories as factories
 from ckan.tests.helpers import call_action
+import ckan.plugins.toolkit as toolkit
+from ckan import model
 
 
 @pytest.mark.ckan_config('ckan.plugins', "who_romania")
@@ -34,3 +36,18 @@ class TestListUsers():
         )
         user_ids_found = [u['id'] for u in response]
         assert user_ids_found == [users[2]['id']]
+
+
+@pytest.mark.ckan_config('ckan.plugins', 'who_romania')
+@pytest.mark.usefixtures('clean_db', 'with_plugins')
+class TestUserShowMe(object):
+
+    def test_no_user(self):
+        with pytest.raises(toolkit.NotAuthorized):
+            call_action('user_show_me', {})
+
+    def test_user(self):
+        user = factories.User()
+        user_obj = model.User.get(user['name'])
+        response = call_action('user_show_me', {'auth_user_obj': user_obj})
+        assert response['name'] == user['name']


### PR DESCRIPTION
Adds the user_show_me action already implemented in the ADR.

This is quite useful when building interoperability/automation.

## Testing

Testing included

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
