### PR TITLE
WRC-17 fix user show me

### DIFF
--- a/ckanext/who_romania/actions.py
+++ b/ckanext/who_romania/actions.py
@@ -37,11 +37,12 @@ def user_show_me(context, resource_dict):
         ```
 
     """
-    auth_user_obj = context.get('auth_user_obj')
-    if auth_user_obj:
-        return auth_user_obj.as_dict()
-    else:
+    model = context['model']
+    auth_user_obj = context.get('auth_user_obj', model.user.AnonymousUser())
+    if isinstance(auth_user_obj, model.user.AnonymousUser):
         raise toolkit.NotAuthorized
+    else:
+        return auth_user_obj.as_dict()
 
 
 def dataset_duplicate(context, data_dict):

--- a/ckanext/who_romania/tests/test_actions.py
+++ b/ckanext/who_romania/tests/test_actions.py
@@ -44,7 +44,17 @@ class TestUserShowMe(object):
 
     def test_no_user(self):
         with pytest.raises(toolkit.NotAuthorized):
-            call_action('user_show_me', {})
+            call_action(
+                'user_show_me',
+                {}
+            )
+
+    def test_anonymous_user(self):
+        with pytest.raises(toolkit.NotAuthorized):
+            call_action(
+                'user_show_me',
+                {'auth_user_obj': model.user.AnonymousUser()}
+            )
 
     def test_user(self):
         user = factories.User()

--- a/test.ini
+++ b/test.ini
@@ -4,7 +4,7 @@ smtp_server = localhost
 error_email_from = ckan@localhost
 
 [app:main]
-use = config:../test-core.ini
+use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini


### PR DESCRIPTION
## Description

The function user_show_me was copied across from the ADR.  ADR is running on older CKAN.  With CKAN 2.10 we use flask login which assigns an object of type "AnonymousUser" when no-one is logged in.  This PR therefor fixes the code to work with this new logic in CKAN 2.10.  Backwards compatibility is not included. 

## Testing

Tests updated accordingly

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
