### PR TITLE
WRC-21 Small UI fixes

### DIFF
--- a/ckanext/who_romania/templates/snippets/changes/new_resource.html
+++ b/ckanext/who_romania/templates/snippets/changes/new_resource.html
@@ -1,0 +1,17 @@
+{% set dataset_type = request.view_args.package_type %}
+{% set pkg_url = h.url_for('dataset.read', id=change.pkg_id) %}
+{% set resource_url = h.url_for('dataset_resource.read', id=change.pkg_id, resource_id = change.resource_id, qualified=True) %}
+
+{% set pkg_link %}
+<a href="{{ pkg_url }}">{{ change.title }}</a>
+{% endset %}
+
+{% set resource_link %}
+<a href="{{ resource_url }}">{{ change.resource_name or _('Unnamed resource') }}</a>
+{% endset %}
+
+<li>
+  <p>
+    {{ _('Added resource {resource_link} to {pkg_link}').format(pkg_link=pkg_link, resource_link=resource_link) }}
+  </p>
+</li>

--- a/ckanext/who_romania/templates/snippets/follow_button.html
+++ b/ckanext/who_romania/templates/snippets/follow_button.html
@@ -9,6 +9,3 @@
     {{ _('Follow') }}
   </a>
 {% endif %}
-<p style="margin-top:10px">
-  {{ _('You can subscribe to email and SMS notifications about followed items in your <a href="/user/edit">user settings</a></p>') }}
-</p>

--- a/ckanext/who_romania/templates/snippets/social.html
+++ b/ckanext/who_romania/templates/snippets/social.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+{% block social %}
+{% endblock %}


### PR DESCRIPTION
## Description

Fixes three small UI issues ahead of demoing the feature on monday. 

1. Removes the links to share data in social media
2. Fixes the changes page that was raising an internal server error
3. Removes any mention of sms and email notifications from the follow button. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
