### PR TITLE
WRC-54 OWASP Secure Headers

### DIFF
--- a/ckanext/who_romania/plugin.py
+++ b/ckanext/who_romania/plugin.py
@@ -167,7 +167,7 @@ class WHORomaniaPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
             if '/view/' not in toolkit.request.path:
                 response.headers['X-Frame-Options'] = 'SAMEORIGIN'
 
-            if 'logged_out_redirect' in response.headers['Location']:
+            if ("Location" in response.headers) and ('logged_out_redirect' in response.headers['Location']):
                 response.headers["Clear-Site-Data"] = "\"*\""
             return response
 

--- a/ckanext/who_romania/plugin.py
+++ b/ckanext/who_romania/plugin.py
@@ -163,6 +163,13 @@ class WHORomaniaPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
             response.headers["HTTP Cross-Origin-Opener-Policy"] = "same-origin"
             response.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
             response.headers["Cross-Origin-Resource-Policy"] = "same-site"
+            response.headers["Content-Security-Policy"] = (
+                "default-src 'self'; "
+                "script-src 'self' https:;"
+                "style-src 'self' 'unsafe-inline' https:;"
+            )
+
+
 
             if '/view/' not in toolkit.request.path:
                 response.headers['X-Frame-Options'] = 'SAMEORIGIN'

--- a/ckanext/who_romania/plugin.py
+++ b/ckanext/who_romania/plugin.py
@@ -34,6 +34,7 @@ class WHORomaniaPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     plugins.implements(plugins.IConfigDeclaration)
     plugins.implements(plugins.IPackageController, inherit=True)
     plugins.implements(plugins.IAuthenticator, inherit=True)
+    plugins.implements(plugins.IMiddleware, inherit = True)
 
     # ITemplateHelpers
     def get_helpers(self):
@@ -150,6 +151,27 @@ class WHORomaniaPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     def after_dataset_create(self, context, data_dict):
         if data_dict.get('private'):
             who_romania_upload.add_activity(context, data_dict, "new")
+
+    def make_middleware(self, app, config):
+        @app.after_request
+        def apply_owasp(response):
+            response.headers['Strict-Transport-Security'] = "max-age=31536000; preload"
+            response.headers['X-Content-Type-Options'] = "nosniff"
+            response.headers["X-Permitted-Cross-Domain-Policies"] = "none" #not sure about this one
+            response.headers["Referrer-Policy"] = "no-referrer-when-downgrade" #this is default when not set
+            response.headers["Cache-Control"] = "public, max-age=0, s-maxage=43200"
+            response.headers["HTTP Cross-Origin-Opener-Policy"] = "same-origin"
+            response.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
+            response.headers["Cross-Origin-Resource-Policy"] = "same-site"
+
+            if '/view/' not in toolkit.request.path:
+                response.headers['X-Frame-Options'] = 'SAMEORIGIN'
+
+            if 'logged_out_redirect' in response.headers['Location']:
+                response.headers["Clear-Site-Data"] = "\"*\""
+            return response
+
+        return app
 
     # IAuthenticator
     def identify(self):


### PR DESCRIPTION
Added secure headers as discussed in https://fjelltopp.atlassian.net/browse/WRC-54

The headers that are set on who.int website are set to the same values. The others are set following recommendation from https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html

The exception is Content Security Policy, that is a bit more complex. [CSP](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html). I have implemented fairly simple CSP, that has one downside - Flask DEBUG toolbar won't show. I think it is something we can live without, right? 

## Testing

Currently tests on Romania CKAN are not working. subject to another PR.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ]  have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
