### PR TITLE
Prevent error when checking size of incorrect resource

### DIFF
--- a/ckanext/who_romania/templates/package/snippets/resource_item.html
+++ b/ckanext/who_romania/templates/package/snippets/resource_item.html
@@ -1,6 +1,8 @@
 {% ckan_extends %}
 
 {% block resource_item_description %}
+    {% if res.size is not none %}
     <p class="resource-detail file-size">{{h.localised_filesize(res.size)}} modified {{h.time_ago_from_timestamp(res.last_modified) }}</p>
+    {% endif %}
     {{ super() }}
 {% endblock %}


### PR DESCRIPTION
One liner change to prevent error when checking size of incorrect resource. Copied from Afro.