### PR TITLE
WRC-68 Fix remove from category button

### DIFF
--- a/ckanext/who_romania/assets/css/who-romania.css
+++ b/ckanext/who_romania/assets/css/who-romania.css
@@ -540,6 +540,7 @@ p.small {
     margin-bottom: 24px;
     padding:  20px;
     height:  110px;
+    position: relative;
 }
 
 .category-box .group-thumbnail {
@@ -573,12 +574,15 @@ p.small {
 
 .category-box .btn-delete {
     background: transparent;
-    color: #00205c;
+    background-color: #00205c;
+    color: #fff;
     font-size: 20px;
-    padding: 20px;
+    line-height: 20px;
+    padding: 5px 10px 5px 7px;
     position: absolute;
-    bottom: 10px;
-    right: 10px;
+    top: 0px;
+    left: 0px;
+    border-radius: 0px 0px 20px 0px;
 }
 
 .dataset-resources li{


### PR DESCRIPTION
## Description

The remove from category button was formatted so that they all appeared in a very wrong place. 

This PR just cleans up the CSS for the remove from category button.

![image](https://github.com/user-attachments/assets/1f2fcfab-2bea-4de3-8dd4-e7a097a5b45f)


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
