### PR TITLE
WRC-66 Get language facet filter working properly

### DIFF
--- a/ckanext/who_romania/plugin.py
+++ b/ckanext/who_romania/plugin.py
@@ -98,7 +98,7 @@ class WHORomaniaPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     def dataset_facets(self, facet_dict, package_type):
         new_fd = OrderedDict()
         new_fd['program_area'] = plugins.toolkit._('Program Areas')
-        new_fd['year'] = plugins.toolkit._('Years')
+        new_fd['language'] = plugins.toolkit._('Language')
         new_fd['tags'] = plugins.toolkit._('Tags')
         return new_fd
 

--- a/ckanext/who_romania/templates/package/search.html
+++ b/ckanext/who_romania/templates/package/search.html
@@ -35,3 +35,15 @@
 
 
 
+{% block secondary_content %}
+  <div class="filters">
+    <div>
+      {% for facet in facet_titles %}
+        {% set scheming_choices=h.scheming_field_by_name(h.scheming_get_dataset_schema(dataset_type).dataset_fields, facet).choices %}
+        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets, scheming_choices=scheming_choices) }}
+      {% endfor %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+  </div>
+{% endblock %}
+

--- a/ckanext/who_romania/templates/snippets/facet_list.html
+++ b/ckanext/who_romania/templates/snippets/facet_list.html
@@ -1,0 +1,40 @@
+{% ckan_extends %}
+
+{% block facet_list_items %}
+{% with items = items or h.get_facet_items_dict(name, search_facets) %}
+    {% if items %}
+    <nav aria-label="{{ title }}">
+        <ul class="list-unstyled nav nav-simple nav-facet">
+        {% for item in items %}
+            {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.name) if scheming_choices else item.display_name}) %}
+            {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
+            {% set label = label_function(item) if label_function else item.display_name %}
+            {% set label_truncated = label|truncate(22) if not label_function else label %}
+            {% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
+            <li class="nav-item {% if item.active %} active{% endif %}">
+            <a href="{{ href }}" title="{{ label if label != label_truncated else '' }}">
+                <span class="item-label">{{ label_truncated }}</span>
+                <span class="hidden separator"> - </span>
+                <span class="item-count badge">{{ count }}</span>
+                {% if item.active %}<span class="facet-close">x</span>{% endif %}
+            </a>
+            </li>
+        {% endfor %}
+
+        </ul>
+    </nav>
+
+    <p class="module-footer">
+        {% if h.get_param_int('_%s_limit' % name) %}
+        {% if h.has_more_facets(name, search_facets) %}
+            <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
+        {% endif %}
+        {% else %}
+        <a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show Only Popular {facet_type}').format(facet_type=title) }}</a>
+        {% endif %}
+    </p>
+    {% else %}
+    <p class="module-content empty">{{ _('There are no {facet_type} that match this search').format(facet_type=title) }}</p>
+    {% endif %}
+{% endwith %}
+{% endblock %}


### PR DESCRIPTION
## Description

Shows the language as a facet filter as requested by Silvia. 

Needed some template changes from WHO AFRO ported over so that scheming select options appear properly in the facet filters. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
