### PR TITLE
WRC-54 Set OWASP headers from config

### DIFF
--- a/ckanext/who_romania/plugin.py
+++ b/ckanext/who_romania/plugin.py
@@ -155,14 +155,38 @@ class WHORomaniaPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     def make_middleware(self, app, config):
         @app.after_request
         def apply_owasp(response):
-            response.headers['Strict-Transport-Security'] = "max-age=31536000; preload"
-            response.headers['X-Content-Type-Options'] = "nosniff"
-            response.headers["X-Permitted-Cross-Domain-Policies"] = "none" #not sure about this one
-            response.headers["Referrer-Policy"] = "no-referrer-when-downgrade" #this is default when not set
-            response.headers["Cache-Control"] = "public, max-age=0, s-maxage=43200"
-            response.headers["HTTP Cross-Origin-Opener-Policy"] = "same-origin"
-            response.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
-            response.headers["Cross-Origin-Resource-Policy"] = "same-site"
+            response.headers['Strict-Transport-Security'] = config.get(
+                "ckanext.who_romania.strict_transport_security",
+                "max-age=31536000; preload"
+            )
+            response.headers['X-Content-Type-Options'] = config.get(
+                "ckanext.who_romania.content_type_options",
+                "nosniff"
+            )
+            response.headers["X-Permitted-Cross-Domain-Policies"] = config.get(
+                "ckanext.who_romania.cross_domain_policies",
+                "none"  # not sure about this one
+            )
+            response.headers["Referrer-Policy"] = config.get(
+                "ckanext.who_romania.referrer_policy",
+                "no-referrer-when-downgrade"   # this is default when not set
+            )
+            response.headers["Cache-Control"] = config.get(
+                "ckanext.who_romania.cache_control",
+                "public, max-age=0, s-maxage=43200"
+            )
+            response.headers["HTTP Cross-Origin-Opener-Policy"] = config.get(
+                "ckanext.who_romania.coop",
+                "same-origin"
+            )
+            response.headers["Cross-Origin-Embedder-Policy"] = config.get(
+                "ckanext.who_romania.coep",
+                "require-corp"
+            )
+            response.headers["Cross-Origin-Resource-Policy"] = config.get(
+                "ckanext.who_romania.corp",
+                "cross-origin"
+            )
             response.headers["Content-Security-Policy"] = config.get(
                 "ckanext.who_romania.content_security_policy",
                 ""


### PR DESCRIPTION
## Description

This PR enables you to tweak all OWASP headers without having to rebuild, by allowing you to override default values with values set in the CKAN config.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
