### PR TITLE
WRC-70 Update get_facet_items_dict with latest changes from core CKAN

### DIFF
--- a/ckanext/who_romania/helpers.py
+++ b/ckanext/who_romania/helpers.py
@@ -1,6 +1,6 @@
 import ckan.logic as logic
 import ckan.model as model
-from ckan.common import c, request, is_flask_request, g
+from ckan.common import request, g
 from datetime import datetime, timedelta
 
 
@@ -33,43 +33,27 @@ def get_facet_items_dict(
     exclude_active -- only return unselected facets.
 
     '''
-    if search_facets is None:
-        search_facets = getattr(c, u'search_facets', None)
-
     if not search_facets \
        or not isinstance(search_facets, dict) \
        or not search_facets.get(facet, {}).get('items'):
         return []
-
     facets = []
-
-    for facet_item in search_facets.get(facet)['items']:
-
+    for facet_item in search_facets[facet]['items']:
         if not len(facet_item['name'].strip()):
             continue
-
-        if is_flask_request():
-            params_items = request.params.items(multi=True)
-        else:
-            params_items = request.params.items()
-
+        params_items = request.args.items(multi=True)
         if not (facet, facet_item['name']) in params_items:
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
-
     # Replace CKAN default sort method
     facets = _facet_sort_function(facet, facets)
-
-    if hasattr(c, 'search_facets_limits'):
-
-        if c.search_facets_limits and limit is None:
-            limit = c.search_facets_limits.get(facet)
-
+    if hasattr(g, 'search_facets_limits'):
+        if g.search_facets_limits and limit is None:
+            limit = g.search_facets_limits.get(facet)
     # zero treated as infinite for hysterical raisins
     if limit is not None and limit > 0:
         return facets[:limit]
-
     return facets
 
 


### PR DESCRIPTION
## Description

Getting ridiculously large numbers of warnings saying:
```
Function is_flask_request() in module ckan.common has been deprecated since CKAN v2.10.0 and will be removed in a later release of ckan. All web requests are served by Flask"
```
The problem is that in order to create our own ordering of facets we had to take a copy of a ckan core helper and make some minor modifications to the middle of it's logic. This code copied from ckan core is now referencing deprecated elements.  

This PR just copies across the latest changes from CKAN core so it is no longer referencing deprecated elements. 

@ChasNelson1990 This change will need to be ported to AFRO as well [here](https://github.com/fjelltopp/ckanext-who-afro/blob/b0e648671ec55f28927854c38005892c34f040e6/ckanext/who_afro/helpers.py#L26-L76).  Should be an exact port I think and super quick. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
