### PR TITLE
WRC-71 Resubmit existing data if fileinput component doesn't load

### DIFF
--- a/ckanext/who_romania/templates/package/snippets/resource_form.html
+++ b/ckanext/who_romania/templates/package/snippets/resource_form.html
@@ -21,6 +21,11 @@
                 <h3 class="text-muted">
                     <span><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</span>
                 </h3>
+                <input name="url" data-testid="url" type="hidden" value="{{ data.url }}">
+                <input name="url_type" data-testid="url_type" type="hidden" value="{{ data.url_type }}">
+                <input name="lfs_prefix" data-testid="lfs_prefix" type="hidden" value="{{ data.lfs_prefix }}">
+                <input name="sha256" data-testid="sha256" type="hidden" value="{{ data.sha256 }}">
+                <input name="size" data-testid="size" type="hidden" value="{{ data.size }}">
             {% else %}
                 <div>
                     <label class="control-label">{{ _('URL')}}</label>

--- a/ckanext/who_romania/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/who_romania/templates/scheming/package/snippets/resource_form.html
@@ -21,6 +21,11 @@
               <h3 class="text-muted">
                   <span><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</span>
               </h3>
+              <input name="url" data-testid="url" type="hidden" value="{{ data.url }}">
+              <input name="url_type" data-testid="url_type" type="hidden" value="{{ data.url_type }}">
+              <input name="lfs_prefix" data-testid="lfs_prefix" type="hidden" value="{{ data.lfs_prefix }}">
+              <input name="sha256" data-testid="sha256" type="hidden" value="{{ data.sha256 }}">
+              <input name="size" data-testid="size" type="hidden" value="{{ data.size }}">
           {% else %}
               <div>
                   <label class="control-label">{{ _('URL')}}</label>


### PR DESCRIPTION
## Description

If user clicks "Update Resource" before the FileInputComponent.js asset loads, the existing giftless metadata (the address to where the file is actually stored) is lost. This creates confusion and corrupt files that can't be downloaded or previewed. 

![image](https://github.com/user-attachments/assets/105b3877-0d64-45fc-ba6f-abb47aa6d624)


This PR just ensures the existing Giftless metadata is submitted with form when the FileInputComponent.js hasn't loaded.  

@ChasNelson1990 This bug was already seen in UNAIDS ADR and may need to be ported to our other projects. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
