### PR TITLE
26 - put the remove from category button back into the UI

### DIFF
--- a/ckanext/who_romania/assets/css/who-romania.css
+++ b/ckanext/who_romania/assets/css/who-romania.css
@@ -128,6 +128,29 @@
     color: #13240F;
 }
 
+.topic-link, .topic-link:hover {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100% !important;
+    font-size: 1em;
+    color: var(--dark);
+    text-decoration: none;
+}
+
+.topics li {
+    width: 30%;
+    border: none;
+}
+
+.topic-link img {
+  flex-shrink: 0;
+}
+
+.topic-link .group-title {
+    padding-left: 10px;
+}
+
 /* groups */
 
 .module.automation{

--- a/ckanext/who_romania/assets/css/who-romania.css
+++ b/ckanext/who_romania/assets/css/who-romania.css
@@ -128,27 +128,56 @@
     color: #13240F;
 }
 
-.topic-link, .topic-link:hover {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100% !important;
-    font-size: 1em;
-    color: var(--dark);
-    text-decoration: none;
+/* category box */
+.dataset .category-box {
+    background: var(--light);
+    border: var(--primary10) 1px solid;
+    border-radius: 6px;
+    margin-bottom: 24px;
+    padding:  20px;
+    height:  110px;
+    position: relative;
 }
 
-.topics li {
-    width: 30%;
-    border: none;
+.dataset .category-box .group-thumbnail {
+    float:  left;
+    display: inline-block;
+    vertical-align: middle;
+    max-height: 70px;
+    margin-right: 20px;
 }
 
-.topic-link img {
-  flex-shrink: 0;
+.dataset .category-box .group-text {
+    vertical-align: middle;
+    width:  100%;
 }
 
-.topic-link .group-title {
-    padding-left: 10px;
+.dataset .category-box .group-text .title{
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 24px;
+    color: var(--primary);
+}
+
+.dataset .category-box .group-text .desc{
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 20px;
+    color: var(--primary);
+    overflow: hidden;
+    height: 50px;
+}
+
+.dataset .category-box .btn-delete {
+    background-color: #00205c;
+    color: var(--light);
+    font-size: 20px;
+    line-height: 20px;
+    padding: 5px 10px 5px 7px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-radius: 0 0 20px 0;
 }
 
 /* groups */

--- a/ckanext/who_romania/templates/group/snippets/group_item.html
+++ b/ckanext/who_romania/templates/group/snippets/group_item.html
@@ -4,19 +4,5 @@
 {% set url = h.url_for(type ~ '.read', id=group.name) %}
 
 {% block item %}
-    <li>
-    {% if group.user_member %}
-        <button name="group_remove.{{ group.id }}"
-                type="submit"
-                class="btn btn-delete btn-sm media-edit"
-                title="{{_('Remove dataset from this group')}}">
-          <i class="fa fa-remove"> </i>
-        </button>
-    {% endif %}
-   <a href="{{ url }}" class="topic-link">
-    <img src="{{ group.image_display_url }}" width="36" alt=""/>
-    <span class="group-title">{{ _(group.title) }}</span>
-  </a>
-    </li>
-
+    <li><a href="{{ url }}"><p class="topic-top-square"><img src="{{ group.image_display_url }}" width="36px"/></p><p class="topic-link">{{ _(group.title) }}</p></a></li>
 {% endblock %}

--- a/ckanext/who_romania/templates/group/snippets/group_item.html
+++ b/ckanext/who_romania/templates/group/snippets/group_item.html
@@ -4,5 +4,19 @@
 {% set url = h.url_for(type ~ '.read', id=group.name) %}
 
 {% block item %}
-    <li><a href="{{ url }}"><p class="topic-top-square"><img src="{{ group.image_display_url }}" width="36px"/></p><p class="topic-link">{{ _(group.title) }}</p></a></li>
+    <li>
+    {% if group.user_member %}
+        <button name="group_remove.{{ group.id }}"
+                type="submit"
+                class="btn btn-delete btn-sm media-edit"
+                title="{{_('Remove dataset from this group')}}">
+          <i class="fa fa-remove"> </i>
+        </button>
+    {% endif %}
+   <a href="{{ url }}" class="topic-link">
+    <img src="{{ group.image_display_url }}" width="36" alt=""/>
+    <span class="group-title">{{ _(group.title) }}</span>
+  </a>
+    </li>
+
 {% endblock %}

--- a/ckanext/who_romania/templates/group/snippets/package_group_item.html
+++ b/ckanext/who_romania/templates/group/snippets/package_group_item.html
@@ -16,7 +16,7 @@
                     <button name="group_remove.{{ group.id }}"
                             type="submit"
                             class="btn btn-delete btn-sm media-edit"
-                            title="{{_('Remove dataset from this group')}}">
+                            title="{{_('Remove dataset from this category')}}">
                       <i class="fa fa-remove"> </i>
                     </button>
                 {% endif %}

--- a/ckanext/who_romania/templates/group/snippets/package_group_item.html
+++ b/ckanext/who_romania/templates/group/snippets/package_group_item.html
@@ -1,0 +1,27 @@
+{% extends 'group/snippets/group_item.html' %}
+
+{% block item %}
+
+    <div class="col-lg-4 col-md-6 col-xs-12">
+        <div class="category-box">
+            <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image group-thumbnail">
+            <div class="group-text">
+                <div class="title">
+                    <a href="{{ url }}">{{ group.title }}</a>
+                </div>
+                {% if group.package_count %}
+                  <div class="desc">{{ ungettext('{num} Dataset', '{num} Datasets', group.package_count).format(num=group.package_count) }}</div>
+                {% endif %}
+                {% if group.user_member %}
+                    <button name="group_remove.{{ group.id }}"
+                            type="submit"
+                            class="btn btn-delete btn-sm media-edit"
+                            title="{{_('Remove dataset from this group')}}">
+                      <i class="fa fa-remove"> </i>
+                    </button>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+{% endblock %}

--- a/ckanext/who_romania/templates/group/snippets/package_group_list.html
+++ b/ckanext/who_romania/templates/group/snippets/package_group_list.html
@@ -1,0 +1,10 @@
+{% extends 'group/snippets/group_list.html' %}
+
+{% block group_list %}
+    {% set groups = groups %}
+        <ul class="topics">
+        {% for group in groups %}
+            {% snippet "group/snippets/package_group_item.html", group=group, position=loop.index %}
+        {% endfor %}
+        </ul>
+{% endblock %}

--- a/ckanext/who_romania/templates/package/group_list.html
+++ b/ckanext/who_romania/templates/package/group_list.html
@@ -19,7 +19,7 @@
   {% if pkg_dict.groups %}
     <form method="post">
       {{ h.csrf_input() }}
-      {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups %}
+      {% snippet 'group/snippets/package_group_list.html', groups=pkg_dict.groups %}
     </form>
   {% else %}
     <p class="empty">{{ _('There are no categories associated with this dataset') }}</p>


### PR DESCRIPTION
## Description

Brings back the 'remove from category' button in **dataset/category**
Does not apply to home/ list of categories and categories/index.
Closes https://github.com/fjelltopp/who-romania-ckan/issues/26

![image](https://github.com/user-attachments/assets/230ea2d9-2f72-4ba8-9bbe-7735e26d0255)


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
